### PR TITLE
ui: move about dialog to its own file

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,6 +1,7 @@
 data/com.github.lachhebo.Gabtag.desktop.in
 data/com.github.lachhebo.Gabtag.appdata.xml.in
 data/com.github.lachhebo.Gabtag.gschema.xml
+src/about_dialog.ui
 src/event_machine.py
 src/main.py
 src/tools.py

--- a/src/about_dialog.ui
+++ b/src/about_dialog.ui
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="GabTagAboutDialog" parent="GtkAboutDialog">
+    <property name="can-focus">False</property>
+    <property name="modal">True</property>
+    <property name="destroy-with-parent">True</property>
+    <property name="type-hint">dialog</property>
+    <property name="logo_icon_name">com.github.lachhebo.Gabtag</property>
+    <property name="program_name">GabTag</property>
+    <property name="comments" translatable="yes">GabTag is an open-source audio tagging tool written in GTK3.</property>
+    <property name="license_type">gpl-3-0</property>
+    <property name="authors">Ismaël Lachheb</property>
+    <!-- TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example' -->
+    <property name="translator-credits" translatable="yes">translator-credits</property>
+    <property name="artists">Tobias Bernard</property>
+  </template>
+</interface>

--- a/src/about_dialog_gtk.py
+++ b/src/about_dialog_gtk.py
@@ -1,0 +1,15 @@
+import gi
+
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gtk  # noqa: E402
+
+
+@Gtk.Template(resource_path='/com/github/lachhebo/Gabtag/about_dialog.ui')
+class GabTagAboutDialog(Gtk.AboutDialog):
+    __gtype_name__ = 'GabTagAboutDialog'
+
+    def __init__(self, parent, version):
+        super().__init__()
+        self.set_transient_for(parent)
+        self.set_version(version)

--- a/src/event_machine.py
+++ b/src/event_machine.py
@@ -3,7 +3,6 @@ from .model import MODEL
 from .selection_handler import SELECTION
 from .controller import Controller
 from .tools import add_filters, get_filenames_from_selection
-from .version import __version__
 
 from gi.repository import Gtk
 
@@ -40,11 +39,6 @@ class EventMachine:
             self.is_real_selection = 0
             Controller.reset_all()
             self.is_real_selection = 1
-
-    def on_about_clicked(self, widget):
-        self.window.id_about_window.set_version(__version__)
-        self.window.id_about_window.run()
-        self.window.id_about_window.hide()
 
     def on_open_clicked(self, widget):
         self.is_real_selection = 0

--- a/src/gabtag.gresource.xml
+++ b/src/gabtag.gresource.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/com/github/lachhebo/Gabtag">
+    <file>about_dialog.ui</file>
     <file>window.ui</file>
   </gresource>
 </gresources>

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,6 +41,7 @@ gabtag_sources = [
   'treeview.py',
   'view.py',
   'window_gtk.py',
+  'about_dialog_gtk.py',
   'controller.py',
   'event_machine.py',
 

--- a/src/window.ui
+++ b/src/window.ui
@@ -1,16 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <object class="GtkAboutDialog" id="id_about_window">
-    <property name="modal">True</property>
-    <property name="logo_icon_name">com.github.lachhebo.Gabtag</property>
-    <property name="program_name">GabTag</property>
-    <property name="comments" translatable="yes">GabTag is an open-source audio tagging tool written in GTK3.</property>
-    <property name="license_type">gpl-3-0</property>
-    <property name="authors">Ismaël Lachheb</property>
-    <!-- TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example' -->
-    <property name="translator-credits" translatable="yes">translator-credits</property>
-    <property name="artists">Tobias Bernard</property>
-  </object>
   <object class="GtkPopoverMenu" id="id_popover_menu">
     <property name="can_focus">False</property>
     <child>
@@ -41,8 +30,8 @@
         <child>
           <object class="GtkModelButton" id="id_about">
             <property name="visible">True</property>
+            <property name="action-name">win.about</property>
             <property name="text" translatable="yes">About GabTag</property>
-            <signal name="clicked" handler="about_clicked" swapped="no"/>
           </object>
         </child>
       </object>

--- a/src/window_gtk.py
+++ b/src/window_gtk.py
@@ -1,5 +1,7 @@
+from .about_dialog_gtk import GabTagAboutDialog
 from .event_machine import EVENT_MACHINE
 from .treeview import TREE_VIEW
+from .version import __version__
 from .view import VIEW
 
 import gi
@@ -7,7 +9,7 @@ import gi
 gi.require_version("Gtk", "3.0")
 gi.require_version("Handy", "1")
 
-from gi.repository import Gtk, Handy  # noqa: E402
+from gi.repository import Gio, Gtk, Handy  # noqa: E402
 
 
 @Gtk.Template(resource_path="/com/github/lachhebo/Gabtag/window.ui")
@@ -16,7 +18,6 @@ class GabtagWindow(Handy.ApplicationWindow):
 
     # HeaderBar
     id_popover_menu = Gtk.Template.Child()
-    id_about_window = Gtk.Template.Child()
 
     # Table
     tree_view_id = Gtk.Template.Child()
@@ -50,7 +51,6 @@ class GabtagWindow(Handy.ApplicationWindow):
     but_open = Gtk.Template.Child()
     id_reset_all = Gtk.Template.Child()
     id_auto_tag = Gtk.Template.Child()
-    id_about = Gtk.Template.Child()
     but_save = Gtk.Template.Child()
     id_load_cover = Gtk.Template.Child()
     id_reset_one = Gtk.Template.Child()
@@ -60,6 +60,12 @@ class GabtagWindow(Handy.ApplicationWindow):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        # About dialog
+
+        about_action = Gio.SimpleAction.new('about', None)
+        about_action.connect('activate', lambda *_: self._show_about_dialog())
+        self.add_action(about_action)
 
         TREE_VIEW.store = self.liststore1
         TREE_VIEW.view = self.tree_view_id
@@ -87,7 +93,6 @@ class GabtagWindow(Handy.ApplicationWindow):
 
         self.id_reset_all.connect("clicked", EVENT_MACHINE.on_reset_all_clicked)
         self.id_auto_tag.connect("clicked", EVENT_MACHINE.on_set_online_tags)
-        self.id_about.connect("clicked", EVENT_MACHINE.on_about_clicked)
         self.but_open.connect("clicked", EVENT_MACHINE.on_open_clicked)
         self.but_save.connect("clicked", EVENT_MACHINE.on_but_saved_clicked)
         self.id_load_cover.connect("clicked", EVENT_MACHINE.on_load_cover_clicked)
@@ -103,3 +108,8 @@ class GabtagWindow(Handy.ApplicationWindow):
         self.id_track.connect("changed", EVENT_MACHINE.on_track_changed)
 
         EVENT_MACHINE.window = self
+
+    def _show_about_dialog(self):
+        dialog = GabTagAboutDialog(self, __version__)
+        dialog.run()
+        dialog.destroy()


### PR DESCRIPTION
Now it truly respects respects modal property.

![imagen](https://user-images.githubusercontent.com/42654671/152005619-d229ceb0-3030-4798-9f93-d4b082d46310.png)

The function that handled the about dialog event has changed but it is possible that the same behavior could be achieved with the current implementation. Trying different ways, this has been the only one in which I have got it to respect the modal property.

Marking this as a draft in case it is possible for you to keep the current implementation of the event, I have not been able to. Feel free to push to my branch.