### PR TITLE
ci: Replace with Flatpak-based

### DIFF
--- a/.github/workflows/flathub-publish.yml
+++ b/.github/workflows/flathub-publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build and publish
       env:
         PASSWORD_DEPLOYEMENT: ${{ secrets.PASSWORD_DEPLOYEMENT }}

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,23 @@
+name: Flatpak
+on:
+  push:
+    branches:
+      - "*"
+    pull_request:
+      - "*"
+
+jobs:
+  flatpak:
+    name: Flatpak
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-42
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v3
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+      with:
+        manifest-path: manifest.json
+        bundle: com.github.lachhebo.Gabtag.flatpak
+        run-tests: true
+        cache-key: flatpak-builder-${{ github.sha }}


### PR DESCRIPTION
It allows to have the latest versions of libraries like libhandy that are not in the ubuntu-latest image (20.04) but in the GNOME 42 container. Also, it will generate a flatpak bundle for testing without having to build it locally for any PR or changes made.

The downside is that the tests will have to be run locally, maybe there is a way to keep them but I can't find any Ubuntu 21.10 image to use with GitHub Actions.