### PR TITLE
app: Port to GTK4 + libadwaita

### DIFF
--- a/com.github.lachhebo.Gabtag.Devel.json
+++ b/com.github.lachhebo.Gabtag.Devel.json
@@ -6,6 +6,7 @@
     "command": "gabtag",
     "finish-args": [
         "--filesystem=home",
+        "--device=dri",
         "--share=network",
         "--share=ipc",
         "--socket=fallback-x11",

--- a/com.github.lachhebo.Gabtag.Devel.json
+++ b/com.github.lachhebo.Gabtag.Devel.json
@@ -66,6 +66,53 @@
             ]
         },
         {
+            "name": "libsass",
+            "sources": [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/sass/libsass/archive/3.6.5.tar.gz",
+                    "sha256": "89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582"
+                },
+                {
+                    "type" : "script",
+                    "dest-filename" : "autogen.sh",
+                    "commands" : [ "autoreconf -si" ]
+                }
+            ]
+        },
+        {
+            "name": "sassc",
+            "sources": [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/sass/sassc/archive/3.6.2.tar.gz",
+                    "sha256": "608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03"
+                },
+                {
+                    "type" : "script",
+                    "dest-filename" : "autogen.sh",
+                    "commands" : [ "autoreconf -si" ]
+                }
+            ]
+        },
+        {
+            "name" : "libadwaita",
+            "buildsystem": "meson",
+            "config-opts" : [
+                "-Dvapi=true",
+                "-Dgtk_doc=false",
+                "-Dexamples=false",
+                "-Dtests=false"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/libadwaita.git",
+                    "branch" : "main"
+                }
+            ]
+        },
+        {
             "name": "gabtag",
             "buildsystem": "meson",
             "builddir": true,

--- a/src/audio_ogg_file_handler.py
+++ b/src/audio_ogg_file_handler.py
@@ -22,7 +22,6 @@ TAG_PARAMS = {
 
 
 class OggFileHandler(AudioExtensionHandler):
-
     @staticmethod
     def get_extension():
         return ".ogg"

--- a/src/controller.py
+++ b/src/controller.py
@@ -14,7 +14,7 @@ import gi
 
 from .view import VIEW
 
-gi.require_version("Gtk", "3.0")
+gi.require_version("Gtk", "4.0")
 
 
 class Controller:

--- a/src/main.py
+++ b/src/main.py
@@ -20,13 +20,12 @@ import sys
 
 from .window_gtk import GabtagWindow
 
-gi.require_version("Gtk", "3.0")
-gi.require_version("Handy", "1")
+gi.require_version("Adw", "1")
 
-from gi.repository import Gtk, Gio, GLib, GObject, Handy  # noqa: E402
+from gi.repository import Adw, Gio, GLib, GObject  # noqa: E402
 
 
-class Application(Gtk.Application):
+class Application(Adw.Application):
 
     app_id = GObject.Property(type=str)
     version = GObject.Property(type=str)
@@ -43,10 +42,8 @@ class Application(Gtk.Application):
         self.version = version
         self.devel = devel
 
-        GLib.set_application_name(("GabTag"))
+        GLib.set_application_name("GabTag")
         GLib.set_prgname(self.app_id)
-        Handy.init()
-        Handy.StyleManager.get_default().set_color_scheme(Handy.ColorScheme.PREFER_LIGHT)
 
     def do_activate(self):
         win = self.props.active_window

--- a/src/tools.py
+++ b/src/tools.py
@@ -9,7 +9,7 @@ import gettext
 from .extension_manager import is_extension_managed
 from .selection_handler import SELECTION
 
-gi.require_version("Gtk", "3.0")
+gi.require_version("Gtk", "4.0")
 
 from gi.repository import Gtk  # noqa: E402
 

--- a/src/treeview.py
+++ b/src/treeview.py
@@ -5,7 +5,7 @@ from gi.repository import Gtk
 
 import gettext
 
-gi.require_version("Gtk", "3.0")
+gi.require_version("Gtk", "4.0")
 
 _ = gettext.gettext
 
@@ -21,12 +21,12 @@ class TreeView:
 
             renderer_filename = Gtk.CellRendererText()
             column_filename = Gtk.TreeViewColumn(
-                _("Name"), renderer_filename, text=0, weight=2, weight_set=True
+                _("Name"), renderer_filename, text=0, weight=2
             )
 
             renderer_data = Gtk.CellRendererText()
             column_data_gathered = Gtk.TreeViewColumn(
-                _("Data"), renderer_data, text=1, weight=2, weight_set=True
+                _("Data"), renderer_data, text=1, weight=2
             )
 
             self.view.append_column(column_data_gathered)

--- a/src/view.py
+++ b/src/view.py
@@ -7,7 +7,7 @@ from gi.repository import GdkPixbuf, GLib
 
 from .tools import set_text_widget_permission, set_label
 
-gi.require_version("Gtk", "3.0")
+gi.require_version("Gtk", "4.0")
 
 
 verrou_tags = RLock()
@@ -76,9 +76,9 @@ class View:
 
                         self.cover_mbz.set_from_pixbuf(pixbuf)
                     except TypeError:
-                        self.cover_mbz.set_from_icon_name("emblem-music-symbolic", 6)
+                        self.cover_mbz.set_from_icon_name("emblem-music-symbolic")
             else:
-                self.cover_mbz.set_from_icon_name("emblem-music-symbolic", 6)
+                self.cover_mbz.set_from_icon_name("emblem-music-symbolic")
 
     def erase(self):
         """
@@ -90,7 +90,7 @@ class View:
         self.artist.set_text("")
         self.year.set_text("")
         self.track.set_text("")
-        self.cover.set_from_icon_name("emblem-music-symbolic", 6)
+        self.cover.set_from_icon_name("emblem-music-symbolic")
         self.last_cover = ""
         self.show_mbz(
             {
@@ -180,7 +180,7 @@ class View:
                     pass
             else:
 
-                self.cover.set_from_icon_name("emblem-music-symbolic", 6)
+                self.cover.set_from_icon_name("emblem-music-symbolic")
                 self.last_cover = ""
 
 

--- a/src/window.ui
+++ b/src/window.ui
@@ -1,52 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <object class="GtkAboutDialog" id="id_about_window">
+  <menu id="main_menu">
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">Reset Files</attribute>
+        <attribute name="action">win.reset-all</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Set Online Tags</attribute>
+        <attribute name="action">win.set-online-tags</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">About GabTag</attribute>
+        <attribute name="action">win.about</attribute>
+      </item>
+    </section>
+  </menu>
+  <object class="AdwAboutWindow" id="id_about_window">
     <property name="modal">True</property>
-    <property name="logo_icon_name">com.github.lachhebo.Gabtag</property>
-    <property name="program_name">GabTag</property>
-    <property name="comments" translatable="yes">GabTag is an open-source audio tagging tool written in GTK3.</property>
-    <property name="license_type">gpl-3-0</property>
-    <property name="authors">Ismaël Lachheb</property>
+    <property name="hide-on-close">True</property>
+    <property name="application-name">GabTag</property>
+    <property name="license-type">gpl-3-0</property>
+    <property name="comments" translatable="yes">Audio tagging tool.</property>
+    <property name="developer-name">Ismaël Lachheb</property>
+    <property name="designers">Tobias Bernard</property>
     <!-- TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example' -->
     <property name="translator-credits" translatable="yes">translator-credits</property>
-    <property name="artists">Tobias Bernard</property>
-  </object>
-  <object class="GtkPopoverMenu" id="id_popover_menu">
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="orientation">vertical</property>
-        <property name="margin">6</property>
-        <child>
-          <object class="GtkModelButton" id="id_reset_all">
-            <property name="visible">True</property>
-            <property name="text" translatable="yes">Reset Files</property>
-            <signal name="clicked" handler="reset_all_clicked" swapped="no"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="id_auto_tag">
-            <property name="visible">True</property>
-            <property name="text" translatable="yes">Set Online Tags</property>
-            <signal name="clicked" handler="on_set_online_tags" swapped="no"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="id_about">
-            <property name="visible">True</property>
-            <property name="text" translatable="yes">About GabTag</property>
-            <signal name="clicked" handler="about_clicked" swapped="no"/>
-          </object>
-        </child>
-      </object>
-    </child>
+    <binding name="transient-for">
+      <lookup name="root" type="GtkWidget"/>
+    </binding>
   </object>
   <object class="GtkListStore" id="liststore1">
     <columns>
@@ -58,507 +42,285 @@
       <column type="gint"/>
     </columns>
   </object>
-  <template class="GabtagWindow" parent="HdyApplicationWindow">
-    <property name="default_width">800</property>
-    <property name="default_height">600</property>
-    <property name="show_menubar">False</property>
-    <child>
+  <template class="GabtagWindow" parent="AdwApplicationWindow">
+    <property name="default-width">800</property>
+    <property name="default-height">600</property>
+    <property name="content">
       <object class="GtkBox">
-        <property name="visible">True</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="HdyHeaderBar" id="header_bar">
-            <property name="visible">True</property>
-            <property name="title">GabTag</property>
-            <property name="subtitle" translatable="yes">Add a Folder to Modify Tags</property>
-            <property name="show_close_button">True</property>
-            <child>
+          <object class="AdwHeaderBar" id="header_bar">
+            <child type="start">
               <object class="GtkButton" id="but_open">
-                <property name="label" translatable="yes">Open</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <signal name="clicked" handler="open_clicked" swapped="no"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuButton" id="id_menu_but">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="popover">id_popover_menu</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">open-menu-symbolic</property>
-                    <property name="icon_size">1</property>
+                <signal name="clicked" handler="on_open_clicked" swapped="no"/>
+                <property name="child">
+                  <object class="AdwButtonContent">
+                    <property name="icon-name">document-open-symbolic</property>
+                    <property name="label" translatable="yes">_Open</property>
+                    <property name="use-underline">True</property>
+                    <property name="tooltip-text" translatable="yes">Select a Folder</property>
                   </object>
-                </child>
+                </property>
               </object>
-              <packing>
-                <property name="pack_type">end</property>
-                <property name="position">1</property>
-              </packing>
             </child>
-            <child>
-              <object class="GtkButton" id="but_save">
-                <property name="label" translatable="yes">Save All</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <signal name="clicked" handler="but_saved_cliqued" swapped="no"/>
+            <child type="end">
+              <object class="GtkMenuButton">
+                <property name="direction">none</property>
+                <property name="menu-model">main_menu</property>
+                <property name="primary">True</property>
+                <property name="tooltip-text" translatable="yes">Main Menu</property>
               </object>
-              <packing>
-                <property name="pack_type">end</property>
-                <property name="position">2</property>
-              </packing>
+            </child>
+            <child type="end">
+              <object class="GtkButton" id="but_save">
+                <property name="icon-name">document-save-symbolic</property>
+                <property name="tooltip-text" translatable="yes">Save All</property>
+                <signal name="clicked" handler="on_but_saved_clicked" swapped="no"/>
+              </object>
             </child>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkPaned" id="panel">
-                <property name="visible">True</property>
-                <child>
-                  <object class="GtkScrolledWindow" id="id_scrolledW">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_width">400</property>
-                    <child>
-                      <object class="GtkTreeView" id="tree_view_id">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="model">liststore1</property>
-                        <property name="enable_search">False</property>
-                        <property name="level_indentation">1</property>
-                        <property name="enable_grid_lines">both</property>
-                        <child internal-child="selection">
-                          <object class="GtkTreeSelection" id="tree_selection_id">
-                            <property name="mode">multiple</property>
-                            <signal name="changed" handler="selected_changed" swapped="no"/>
-                          </object>
-                        </child>
+          <object class="GtkPaned">
+            <property name="shrink-start-child">False</property>
+            <property name="shrink-end-child">False</property>
+            <property name="position">400</property>
+            <property name="start-child">
+              <object class="GtkScrolledWindow">
+                <property name="hscrollbar-policy">never</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="child">
+                  <object class="GtkTreeView" id="tree_view_id">
+                    <property name="model">liststore1</property>
+                    <property name="level-indentation">1</property>
+                    <property name="enable-grid-lines">both</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection" id="tree_selection_id">
+                        <property name="mode">multiple</property>
+                        <signal name="changed" handler="selected_changed" swapped="no"/>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="shrink">False</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkScrolledWindow">
-                    <property name="visible">True</property>
-                    <property name="hscrollbar-policy">never</property>
-                    <child>
+                </property>
+              </object>
+            </property>
+            <property name="end-child">
+              <object class="GtkScrolledWindow">
+                <property name="hscrollbar-policy">never</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="child">
+                  <object class="AdwClamp">
+                    <property name="child">
                       <object class="GtkBox">
-                        <property name="visible">True</property>
                         <property name="orientation">vertical</property>
-                        <property name="can_focus">False</property>
-                        <property name="valign">start</property>
-                        <property name="expand">True</property>
+                        <property name="margin-top">36</property>
+                        <property name="margin-bottom">36</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
+                        <property name="spacing">24</property>
+                        <child>
+                          <object class="GtkButton" id="id_load_cover">
+                            <property name="tooltip-text" translatable="yes">Load a Cover</property>
+                            <property name="halign">center</property>
+                            <property name="height-request">256</property>
+                            <property name="width-request">256</property>
+                            <property name="css-classes">card</property>
+                            <signal name="clicked" handler="load_cover_clicked" swapped="no"/>
+                            <property name="child">
+                              <object class="GtkImage" id="id_cover">
+                                <property name="icon-name">emblem-music-symbolic</property>
+                                <property name="pixel-size">64</property>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label" translatable="yes">Cover</property>
+                            <property name="halign">center</property>
+                            <property name="css-classes">title-1</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkListBox">
+                            <property name="selection-mode">none</property>
+                            <property name="css-classes">boxed-list</property>
+                            <child>
+                              <object class="AdwEntryRow" id="id_title">
+                                <property name="title" translatable="yes">Title</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwEntryRow" id="id_album">
+                                <property name="title" translatable="yes">Album</property>
+                                <signal name="changed" handler="album_changed" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwEntryRow" id="id_artist">
+                                <property name="title" translatable="yes">Artist</property>
+                                <signal name="changed" handler="artist_changed" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwEntryRow" id="id_type">
+                                <property name="title" translatable="yes">Genre</property>
+                                <signal name="changed" handler="type_changed" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwEntryRow" id="id_track">
+                                <property name="title" translatable="yes">Track</property>
+                                <signal name="changed" handler="track_changed" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwEntryRow" id="id_year">
+                                <property name="title" translatable="yes">Year</property>
+                                <property name="input-purpose">digits</property>
+                                <signal name="changed" handler="year_changed" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Length</property>
+                                <property name="css-classes">dim-label</property>
+                                <child>
+                                  <object class="GtkLabel" id="id_info_length">
+                                    <property name="css-classes">dim-label</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Size</property>
+                                <property name="css-classes">dim-label</property>
+                                <child>
+                                  <object class="GtkLabel" id="id_info_size">
+                                    <property name="css-classes">dim-label</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
                         <child>
                           <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="orientation">vertical</property>
-                            <property name="can_focus">False</property>
-                            <property name="expand">True</property>
+                            <property name="margin-bottom">36</property>
                             <child>
-                              <object class="GtkButton" id="id_load_cover">
-                                <property name="visible">True</property>
-                                <property name="tooltip_text" translatable="yes">Load a Cover (JPEG or PNG)</property>
+                              <object class="GtkButton" id="id_reset_one">
+                                <property name="label" translatable="yes">Reset</property>
+                                <property name="tooltip-text" translatable="yes">Remove Changes in Fields</property>
                                 <property name="halign">center</property>
                                 <property name="valign">center</property>
-                                <property name="height-request">250</property>
-                                <property name="width-request">250</property>
-                                <property name="margin_top">36</property>
-                                <signal name="clicked" handler="load_cover_clicked" swapped="no"/>
-                                <child>
-                                  <object class="GtkImage" id="id_cover">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">emblem-music-symbolic</property>
-                                    <property name="icon_size">6</property>
-                                    <property name="halign">center</property>
-                                    <property name="valign">center</property>
-                                  </object>
-                                </child>
+                                <property name="hexpand">True</property>
+                                <signal name="clicked" handler="reset_one_clicked" swapped="no"/>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                              </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Cover</property>
+                              <object class="GtkButton" id="id_save_one">
+                                <property name="label" translatable="yes">Save</property>
+                                <property name="tooltip-text" translatable="yes">Store Changes to File</property>
                                 <property name="halign">center</property>
-                                <property name="xalign">0</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap-mode">word-char</property>
-                                <property name="justify">center</property>
-                                <property name="margin_top">12</property>
-                                <property name="margin_bottom">36</property>
-                                <style>
-                                  <class name="title"/>
-                                  <class name="large-title"/>
-                                </style>
+                                <property name="valign">center</property>
+                                <property name="hexpand">True</property>
+                                <signal name="clicked" handler="clicked_save_one" swapped="no"/>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
                         <child>
-                          <object class="HdyClamp">
-                            <property name="visible">True</property>
-                            <property name="maximum-size">400</property>
-                            <property name="tightening-threshold">300</property>
+                          <object class="GtkLabel" id="id_label_mbz">
+                            <property name="label" translatable="yes">MusicBrainz Tags</property>
+                            <property name="css-classes">title-2</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkImage" id="id_cover_mbz">
+                            <property name="icon-name">emblem-music-symbolic</property>
+                            <property name="height-request">256</property>
+                            <property name="width-request">256</property>
+                            <property name="pixel-size">64</property>
+                            <property name="margin-top">12</property>
+                            <property name="margin-bottom">12</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkListBox">
+                            <property name="selection-mode">none</property>
+                            <property name="css-classes">boxed-list</property>
                             <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="valign">center</property>
-                                <property name="hexpand">True</property>
-                                <property name="orientation">vertical</property>
-                                <property name="spacing">6</property>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Title</property>
                                 <child>
-                                  <object class="GtkListBox">
-                                    <property name="visible">True</property>
-                                    <property name="expand">True</property>
-                                    <property name="selection-mode">none</property>
-                                    <style>
-                                      <class name="content"/>
-                                    </style>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Title</property>
-                                        <child>
-                                          <object class="GtkEntry" id="id_title">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <signal name="changed" handler="title_changed" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Album</property>
-                                        <child>
-                                          <object class="GtkEntry" id="id_album">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <signal name="changed" handler="album_changed" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Artist</property>
-                                        <child>
-                                          <object class="GtkEntry" id="id_artist">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <signal name="changed" handler="artist_changed" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Genre</property>
-                                        <child>
-                                          <object class="GtkEntry" id="id_type">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <signal name="changed" handler="type_changed" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Track</property>
-                                        <child>
-                                          <object class="GtkEntry" id="id_track">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <signal name="changed" handler="track_changed" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Year</property>
-                                        <child>
-                                          <object class="GtkEntry" id="id_year">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <signal name="changed" handler="year_changed" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Length</property>
-                                        <style>
-                                          <class name="dim-label"/>
-                                        </style>
-                                        <child>
-                                          <object class="GtkLabel" id="id_info_length">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <style>
-                                              <class name="dim-label"/>
-                                            </style>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Size</property>
-                                        <style>
-                                          <class name="dim-label"/>
-                                        </style>
-                                        <child>
-                                          <object class="GtkLabel" id="id_info_size">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <style>
-                                              <class name="dim-label"/>
-                                            </style>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
+                                  <object class="GtkLabel" id="id_title_mbz">
                                   </object>
                                 </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Album</property>
                                 <child>
-                                  <object class="GtkListBox">
-                                    <property name="visible">True</property>
-                                    <property name="expand">True</property>
-                                    <property name="selection-mode">none</property>
-                                    <property name="margin_bottom">36</property>
-                                    <style>
-                                      <class name="background">none</class>
-                                    </style>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <child>
-                                          <object class="GtkButton" id="id_reset_one">
-                                            <property name="label" translatable="yes">Reset</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
-                                            <property name="tooltip_text" translatable="yes">Remove modification made to fields</property>
-                                            <property name="halign">center</property>
-                                            <property name="valign">center</property>
-                                            <property name="expand">True</property>
-                                            <signal name="clicked" handler="reset_one_clicked" swapped="no"/>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="id_save_one">
-                                            <property name="label" translatable="yes">Save</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
-                                            <property name="tooltip_text" translatable="yes">Save modification made to this file</property>
-                                            <property name="halign">center</property>
-                                            <property name="valign">center</property>
-                                            <property name="expand">True</property>
-                                            <signal name="clicked" handler="clicked_save_one" swapped="no"/>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
+                                  <object class="GtkLabel" id="id_album_mbz"/>
                                 </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Artist</property>
                                 <child>
-                                  <object class="GtkLabel" id="id_label_mbz">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">MusicBrainz Tags</property>
-                                    <property name="halign">center</property>
-                                    <property name="valign">center</property>
-                                    <property name="expand">True</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
+                                  <object class="GtkLabel" id="id_artist_mbz"/>
                                 </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Genre</property>
                                 <child>
-                                  <object class="GtkImage" id="id_cover_mbz">
-                                    <property name="visible">True</property>
-                                    <property name="icon_name">emblem-music-symbolic</property>
-                                    <property name="icon_size">6</property>
-                                    <property name="halign">center</property>
-                                    <property name="valign">center</property>
-                                    <property name="height-request">250</property>
-                                    <property name="width-request">250</property>
-                                    <property name="margin_top">12</property>
-                                    <property name="margin_bottom">12</property>
-                                  </object>
+                                  <object class="GtkLabel" id="id_genre_mbz"/>
                                 </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Track</property>
                                 <child>
-                                  <object class="GtkListBox">
-                                    <property name="visible">True</property>
-                                    <property name="expand">True</property>
-                                    <property name="selection-mode">none</property>
-                                    <style>
-                                      <class name="content"/>
-                                    </style>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Title</property>
-                                        <child>
-                                          <object class="GtkLabel" id="id_title_mbz">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <property name="label" translatable="yes">Title</property>
-                                            <style>
-                                              <class name="dim-label"/>
-                                            </style>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Album</property>
-                                        <child>
-                                          <object class="GtkLabel" id="id_album_mbz">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <property name="label" translatable="yes">Album</property>
-                                            <style>
-                                              <class name="dim-label"/>
-                                            </style>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Artist</property>
-                                        <child>
-                                          <object class="GtkLabel" id="id_artist_mbz">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <property name="label" translatable="yes">Artist</property>
-                                            <style>
-                                              <class name="dim-label"/>
-                                            </style>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Genre</property>
-                                        <child>
-                                          <object class="GtkLabel" id="id_genre_mbz">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <property name="label" translatable="yes">Genre</property>
-                                            <style>
-                                              <class name="dim-label"/>
-                                            </style>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Track</property>
-                                        <child>
-                                          <object class="GtkLabel" id="id_track_mbz">
-                                            <property name="visible">True</property>
-                                            <property name="valign">center</property>
-                                            <property name="label" translatable="yes">Track</property>
-                                            <style>
-                                              <class name="dim-label"/>
-                                            </style>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="HdyActionRow">
-                                        <property name="visible">True</property>
-                                        <property name="title" translatable="yes">Year</property>
-                                        <child>
-                                          <object class="GtkLabel" id="id_year_mbz">
-                                            <property name="visible">True</property>
-                                            <property name="label" translatable="yes">Year</property>
-                                            <style>
-                                              <class name="dim-label"/>
-                                            </style>
-                                            <property name="valign">center</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
+                                  <object class="GtkLabel" id="id_track_mbz"/>
                                 </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Year</property>
                                 <child>
-                                  <object class="GtkButton" id="id_setmbz_but">
-                                    <property name="label" translatable="yes">Set Tags</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="tooltip_text" translatable="yes">Use the MusicBrainz tags</property>
-                                    <property name="halign">center</property>
-                                    <property name="valign">center</property>
-                                    <property name="expand">True</property>
-                                    <property name="margin_top">8</property>
-                                    <property name="margin_bottom">36</property>
-                                    <signal name="clicked" handler="on_set_mbz" swapped="no"/>
-                                  </object>
+                                  <object class="GtkLabel" id="id_year_mbz"/>
                                 </child>
                               </object>
                             </child>
                           </object>
                         </child>
+                        <child>
+                          <object class="GtkButton" id="id_setmbz_but">
+                            <property name="label" translatable="yes">Set Tags</property>
+                            <property name="tooltip-text" translatable="yes">Use MusicBrainz Tags</property>
+                            <property name="halign">center</property>
+                            <signal name="clicked" handler="on_set_mbz" swapped="no"/>
+                          </object>
+                        </child>
                       </object>
-                    </child>
+                    </property>
                   </object>
-                  <packing>
-                    <property name="shrink">False</property>
-                  </packing>
-                </child>
+                </property>
               </object>
-            </child>
+            </property>
           </object>
-          <packing>
-            <property name="expand">True</property>
-          </packing>
         </child>
       </object>
-    </child>
+    </property>
   </template>
 </interface>
+

--- a/src/window_gtk.py
+++ b/src/window_gtk.py
@@ -4,14 +4,14 @@ from .view import VIEW
 
 import gi
 
-gi.require_version("Gtk", "3.0")
-gi.require_version("Handy", "1")
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
 
-from gi.repository import Gtk, GObject, Handy  # noqa: E402
+from gi.repository import Adw, Gio, GObject, Gtk  # noqa: E402
 
 
 @Gtk.Template(resource_path="/com/github/lachhebo/Gabtag/window.ui")
-class GabtagWindow(Handy.ApplicationWindow):
+class GabtagWindow(Adw.ApplicationWindow):
     __gtype_name__ = "GabtagWindow"
 
     app_id = GObject.Property(type=str)
@@ -19,7 +19,6 @@ class GabtagWindow(Handy.ApplicationWindow):
     devel = GObject.Property(type=bool, default=False)
 
     # HeaderBar
-    id_popover_menu = Gtk.Template.Child()
     id_about_window = Gtk.Template.Child()
 
     # Table
@@ -52,9 +51,6 @@ class GabtagWindow(Handy.ApplicationWindow):
     # Buttons
 
     but_open = Gtk.Template.Child()
-    id_reset_all = Gtk.Template.Child()
-    id_auto_tag = Gtk.Template.Child()
-    id_about = Gtk.Template.Child()
     but_save = Gtk.Template.Child()
     id_load_cover = Gtk.Template.Child()
     id_reset_one = Gtk.Template.Child()
@@ -66,17 +62,17 @@ class GabtagWindow(Handy.ApplicationWindow):
         super().__init__(**kwargs)
 
         if devel:
-            self.get_style_context().add_class("devel")
+            self.add_css_class("devel")
 
         self.set_default_icon_name(app_id)
-        self.id_about_window.set_logo_icon_name(app_id)
+        self.id_about_window.set_application_icon(app_id)
         self.id_about_window.set_version(version)
 
         TREE_VIEW.store = self.liststore1
         TREE_VIEW.view = self.tree_view_id
         TREE_VIEW.add_columns()
 
-        VIEW.tree_view_id = self.tree_view_id
+        VIEW.tree_view = self.tree_view_id
         VIEW.title = self.id_title
         VIEW.album = self.id_album
         VIEW.artist = self.id_artist
@@ -96,13 +92,23 @@ class GabtagWindow(Handy.ApplicationWindow):
 
         # Connect Buttons
 
-        self.id_reset_all.connect("clicked", EVENT_MACHINE.on_reset_all_clicked)
-        self.id_auto_tag.connect("clicked", EVENT_MACHINE.on_set_online_tags)
-        self.id_about.connect("clicked", EVENT_MACHINE.on_about_clicked)
         self.but_open.connect("clicked", EVENT_MACHINE.on_open_clicked)
         self.but_save.connect("clicked", EVENT_MACHINE.on_but_saved_clicked)
+
+        reset_all = Gio.SimpleAction.new("reset-all", None)
+        reset_all.connect("activate", EVENT_MACHINE.on_reset_all_clicked)
+        self.add_action(reset_all)
+
+        set_online_tags = Gio.SimpleAction.new("set-online-tags", None)
+        set_online_tags.connect("activate", EVENT_MACHINE.on_set_online_tags)
+        self.add_action(set_online_tags)
+
+        about = Gio.SimpleAction.new("about", None)
+        about.connect("activate", EVENT_MACHINE.on_about_clicked)
+        self.add_action(about)
+
         self.id_load_cover.connect("clicked", EVENT_MACHINE.on_load_cover_clicked)
-        self.id_reset_one.connect("clicked", EVENT_MACHINE.on_reset_all_clicked)
+        self.id_reset_one.connect("clicked", EVENT_MACHINE.on_reset_one_clicked)
         self.id_save_one.connect("clicked", EVENT_MACHINE.on_clicked_save_one)
         self.id_setmbz_but.connect("clicked", EVENT_MACHINE.on_set_mbz)
         self.tree_selection_id.connect("changed", EVENT_MACHINE.on_selected_changed)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -4,7 +4,7 @@ import gi
 
 from src.controller import Controller
 
-gi.require_version("Gtk", "3.0")
+gi.require_version("Gtk", "4.0")
 
 
 TESTED_MODULE = "src.controller"


### PR DESCRIPTION
~(Commits are on top of the PRs I opened previously). I'll try to split this PR into smaller ones if they aren't strictly required for the port.~

The purpose of this PR is to do a 1:1 port; without changing the interface layout, at least not in this one 😉 

Flatpak CI should output a working [build](https://github.com/oscfdezdz/GabTag/suites/7850589083/artifacts/332485248) in my fork's branch.

Help to complete the port is always welcome 😄

### Progress

### Buttons:
- [x] Open
- [x] Save All ~(works installing it as a system package, but not as a Flatpak)~
- [x] Reset Files (doesn't reset bold text on TreeView)
- [x] Set Online Tags
- [x] About GabTag
- [x] Load Cover
- [x] Reset (is set to Reset All button on [master](https://github.com/lachhebo/GabTag/blob/5d43569af4b263fc7366db228421b57fd8f2e4fd/src/window_gtk.py#L94), probably out of scope of this PR (?))
- [x] Save ~(works installing it as a system package, but not as a Flatpak)~
- [x] Set Tags

### Widgets:
- [ ] TreeView ([open related issues in GTK](https://gitlab.gnome.org/GNOME/gtk/-/issues/?search=gtk_css_node_insert_after%3A%20assertion%20%27previous_sibling%20%3D%3D%20NULL%20%7C%7C%20previous_sibling-%3Eparent%20%3D%3D%20parent%27%20failed&sort=updated_desc&state=opened&first_page_size=20))
```sh
Gtk-CRITICAL **: gtk_css_node_insert_after: assertion 'previous_sibling == NULL || previous_sibling->parent == parent' failed
```

### UI:
- [x] Paned (limit minimum size)
- [ ] `</style>` tag instead of `css-classes` property
It doesn't currently work and there seems to be no reason why it shouldn't.

### Tests are passing now!

![image](https://user-images.githubusercontent.com/42654671/184049485-4c8a40ed-7456-47e7-b7cb-743d81619da2.png)